### PR TITLE
Feature/news contents types detail

### DIFF
--- a/global-templates/get_contents.vm
+++ b/global-templates/get_contents.vm
@@ -200,15 +200,10 @@
                                 ##COMPROBACION DE VERSION DE ITER PARA PARAMETRO SIZES
                                 #if($imgHtml)##SOPORTE PARA PARAMETRO SIZES
                                     $imgHtml
-
-				
-
                                 #else##SIN SOPORTE PARAPARAMETRO SIZES
-
-				   
-
                                     $!articleToolbox.getImageTag("$el.name","$el.Milenium.data","$cropName","","","","false","$!$AltImage","$!TitleImage")
-                                #end							
+                                #end	
+
                                 #if($el.Cutline && $el.Cutline.data != "")
 									#if ($environment == 'PREVIEW')
 											#set($tempIter = "mlnid='$el.Cutline.Milenium.data' ")
@@ -225,7 +220,6 @@
 									</div>
                                 #end
 						</figure>
-						
 					</$cont.tag>
 				#end
 				#if($cont.type == "twitter") ## CONTENIDOS DE TIPO TWITTER
@@ -257,49 +251,57 @@
                         <$cont.tag class="multimediaMacroWrapper ${cont.cssclass}" itemprop="video"  $!tempIter >
                             <iframe allowfullscreen="" frameborder="0" height="$heightMultimedia"  width="$widthMultimedia" src="//www.youtube.com/embed/$el.data?wmode=transparent&controls=2&showinfo=0&theme=light"></iframe>
                         </$cont.tag>
-
-						
+					#end
+				#end
+				#if($cont.type == "instagram")
+					#if($el && $el.trim() != "")
+						#if ($environment == 'PREVIEW')
+                            #set($tempIter = " iterhtmlid='$el.Milenium.data' ")
+                        #else
+                            #set($tempIter = "")		
+		                #end
+						<$cont.tag class="multimediaMacroWrapper ${cont.cssclass}"  itemprop="instagram_post" $!tempIter>
+								<iframe width="$!widthMultimedia" height="$!heightMultimedia" src="//www.instagram.com/p/${el.data}/embed" frameborder="0"></iframe>
+						</$cont.tag>
+					#end
+				#end
+				#if($cont.type == "facebook")
+					#if($el && $el.trim() != "")
+						#if ($environment == 'PREVIEW')
+                            #set($tempIter = " iterhtmlid='$el.Milenium.data' ")
+                        #else
+                            #set($tempIter = "")		
+		                #end
+						<$cont.tag class="multimediaMacroWrapper ${cont.cssclass}" itemprop="facebook_post" $!tempIter>
+							<div class="fb-post" data-href="$!el.data.trim()"></div>
+						</$cont.tag>
 					#end
 				#end
 				#if($cont.type == "vimeo") ## CONTENIDOS DE TIPO VIDEO VIMEO
 					#if($el && $el.trim() != "")
-
-
-                         
-
                         #if ($environment == 'PREVIEW')
                             #set($tempIter = " iterhtmlid='$el.Milenium.data' ")
                         #else
                             #set($tempIter = "")		
 		                #end
-
                          <$cont.tag class="multimediaMacroWrapper ${cont.cssclass}" itemprop="video"  $!tempIter >
                             <iframe class="vimeo-player" src="//player.vimeo.com/video/$el.data" width="$widthMultimedia" height="$heightMultimedia" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 						 </$cont.tag>
-
-
-						
 					#end
 				#end
 				#if($cont.type == "multimedia") ## CONTENIDOS DE TIPO JWPLAYER
 				   #if($el && $el.trim() != "")
-
-
                         #if ($environment == 'PREVIEW')
                             #set($tempIter = " iterhtmlid='$el.Milenium.data' ")
                         #else
                             #set($tempIter = "")		
 		                #end
-
-                         <$cont.tag class="multimediaMacroWrapper ${cont.cssclass}"  $!tempIter >
+                        <$cont.tag class="multimediaMacroWrapper ${cont.cssclass}"  $!tempIter >
                             <div id="multimediaPlayer${reserved-article-id.data}${velocityCount}">Cargando reproductor ...</div>		
                             <script type="text/javascript">
                                 initJwPlayer("$el.Preview.data","$el.Document.data","multimediaPlayer${reserved-article-id.data}${velocityCount}","$widthMultimedia","$heightMultimedia");									
                             </script>
                         </$cont.tag>
-
-
-						
 					#end             
 				#end
 				#if($cont.type == "paragraph") ## CONTENIDOS DE TIPO TEXTO CON PARRAFOS

--- a/global-templates/order_text.vm
+++ b/global-templates/order_text.vm
@@ -217,9 +217,20 @@
                 #if($el && $el.trim() != "")
                     <div class="multimediaMacroWrapper">
                         <div class="contentMedia art-instagram"  iterhtmlid="$el.Milenium.data">
-                            <div class="responsive-video" itemprop="instagram">
-                                <iframe width="$!widthMultimedia" height="$!heightMultimedia" src="http://instagram.com/p/${el.data}/embed" frameborder="0"></iframe>
+                            <div class="responsive-video" itemprop="instagram_post">
+                                <iframe width="$!widthMultimedia" height="$!heightMultimedia" src="//www.instagram.com/p/${el.data}/embed" frameborder="0"></iframe>
                             </div>  
+                        </div>
+                    </div>
+                #end
+            #end
+            #if($element.name == "Facebook_Text")
+                #if($el && $el.trim() != "")
+                    <div class="multimediaMacroWrapper">
+                        <div class="contentMedia art-facebook" iterhtmlid="$el.Milenium.data">
+                            <div class="responsive-video" itemprop="facebook_post">
+                                <div class="fb-post" data-href="$!el.data.trim()"></div>
+                            </div>
                         </div>
                     </div>
                 #end
@@ -322,6 +333,7 @@
             #set ($temp = $hashNames.put("Youtube_Text","Youtube_Text"))
             #set ($temp = $hashNames.put("Twitter_Text","Twitter_Text"))
             #set ($temp = $hashNames.put("Facebook_Text","Facebook_Text"))
+            #set ($temp = $hashNames.put("Instagram_Text","Instagram_Text"))
             #set ($temp = $hashNames.put("Maps_Text","Maps_Text"))
             #set ($temp = $hashNames.put("Multimedia_Text","Multimedia_Text"))
             #set ($temp = $hashNames.put("Vimeo_Text","Vimeo_Text"))

--- a/global-templates/order_text.vm
+++ b/global-templates/order_text.vm
@@ -202,7 +202,6 @@
                     #set($arraImgTemp = [])
                 #end
             #end
-    
             #if($element.name == "Youtube_Text")
                 #if($el && $el.trim() != "")
                     <div class="multimediaMacroWrapper">
@@ -214,8 +213,18 @@
                     </div>
                 #end
             #end
-            
-             #if($element.name == "Vimeo_Text")
+            #if($element.name == "Instagram_Text")
+                #if($el && $el.trim() != "")
+                    <div class="multimediaMacroWrapper">
+                        <div class="contentMedia art-instagram"  iterhtmlid="$el.Milenium.data">
+                            <div class="responsive-video" itemprop="instagram">
+                                <iframe width="$!widthMultimedia" height="$!heightMultimedia" src="http://instagram.com/p/${el.data}/embed" frameborder="0"></iframe>
+                            </div>  
+                        </div>
+                    </div>
+                #end
+            #end
+            #if($element.name == "Vimeo_Text")
                 #if($el && $el.trim() != "")
                     <div class="multimediaMacroWrapper">
                         <div class="contentMedia art-vimeo"  iterhtmlid="$el.Milenium.data">
@@ -226,8 +235,7 @@
                     </div>
                 #end
             #end
-
-        #if($element.name == "Twitter_Text")
+            #if($element.name == "Twitter_Text")
                 #if($el && $el.trim() != "")
                         <div class="art-twitter"  iterhtmlid="$el.Milenium.data">
                             <div class="twitter-content" itemprop="tweet">
@@ -239,7 +247,6 @@
                         </div>
                 #end
             #end
-            
             #if($element.name == "Multimedia_Text")
                #if($el && $el.trim() != "")
                     <div class="multimediaMacroWrapper">
@@ -254,21 +261,16 @@
                     </div>
                 #end             
             #end        
-      
             #if($element.name == "HTML_Text")
                 #if($el.data && $el.data.trim() != "")
                     <div class='${element.cssclass}'>$!el.data.trim().replaceAll("&","&")</div>
                 #end                                    
             #end
-               
-            
             #if($element.name == "Lead")
                 #if($el && $el.trim() != "")
                     <h2 class='${element.cssclass} cita' mlnid="$el.Milenium.data">$!el.data.trim().replaceAll("&","&")</h2>
                 #end                                    
             #end
-            
-    
             #if($element.name == "Text")
                 #if($el && $el.trim() != "")
                     <div class='paragraph' mlnid="$el.Milenium.data">
@@ -281,8 +283,7 @@
                         #end
                     </div>
                 #end
-            #end    
-            
+            #end     
             #if($element.name == "Intext")
                 #if($el && $el.trim() != "")
                     <div class='${element.cssclass}' mlnid="$el.Milenium.data">
@@ -290,7 +291,6 @@
                     </div>
                 #end
             #end
-            
             #if($element.name == "Quote")
                 #if($el && $el.trim() != "")
                     <blockquote class='${element.cssclass}' mlnid="$el.Milenium.data">
@@ -298,8 +298,6 @@
                     </blockquote>   
                 #end
             #end    
-            
-            
             #if($element.name == "Destacado")
                 #if($el && $el.trim() != "")
                     <div class='${element.cssclass}' mlnid="$el.Milenium.data">


### PR DESCRIPTION
Se han añadido dos nuevos tipos de contenidos en la recuperación de tipos de contenidos en la corriente del texto en el detalle de los artículos. Los dos nuevos tipos de contenido son Facebook_Text e Instagram_Text. Estos tipos de contenido esperan una url y un código respectivamente. 

Este desarrollo se ha añadido para aprovechar estos contenidos en las versiones de AMP y no usar el tipo de contenido HTML_Text que puede ocasionar problemas en dicha versión AMP.

Las macros afectadas serían #getTextFlow en la cual se ha añadido al array el tipo de contenido Instagram_Text, #printHTMLContentDetalle y printHTMLContentArticle_v1 en las cuales se añadió el html necesario para montar los post de Facebook e Instagram.